### PR TITLE
Add vim-scripts on Plug plugin

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -93,7 +93,7 @@ Plug 'sheerun/vim-polyglot'
 
 " HTML / JS / CSS
 Plug 'othree/html5.vim'
-Plug 'html-improved-indentation'
+Plug 'vim-scripts/html-improved-indentation'
 Plug 'pangloss/vim-javascript'
 Plug 'flowtype/vim-flow'
 Plug 'wokalski/autocomplete-flow'


### PR DESCRIPTION

``` 
[vim-plug] Invalid argument: html-improved-indentation (implicit `vim-scripts' expansion is deprecated)
``` 